### PR TITLE
Changed the logo image for Synth subnet

### DIFF
--- a/data/50/subnet.json
+++ b/data/50/subnet.json
@@ -3,13 +3,17 @@
   "bittensor_id": "",
   "letter": "",
   "name": "Synth",
-  "github": ["https://github.com/mode-network/synth-subnet"],
+  "github": [
+    "https://github.com/mode-network/synth-subnet"
+  ],
   "hw_requirements": "",
-  "image_url": "https://backprop.finance/assets/subnet-logos/50/v1.jpg",
+  "image_url": "https://backprop.finance/assets/subnet-logos/50/v2.jpg",
   "description": "",
   "bittensor_discord_id": "1311109830282313781",
   "team": "Mode Network",
-  "categories": ["DeFi"],
+  "categories": [
+    "DeFi"
+  ],
   "summary": "Synth creates the world's most powerful Synthetic price data for DeFi, enabling a paradigm shift in how agents model and optimise for the future.",
   "websites": [
     {

--- a/subnets.json
+++ b/subnets.json
@@ -1636,7 +1636,7 @@
             "https://github.com/mode-network/synth-subnet"
         ],
         "hw_requirements": "",
-        "image_url": "https://backprop.finance/assets/subnet-logos/50/v1.jpg",
+        "image_url": "https://backprop.finance/assets/subnet-logos/50/v2.jpg",
         "description": "",
         "bittensor_discord_id": "1311109830282313781",
         "team": "Mode Network",


### PR DESCRIPTION
We need to change the Mode logo that's currently there for the Synth logo, you can download the logo here:

https://drive.google.com/file/d/1KgKCdAHixP5TfR2XOlXG-pF2zUUk1p21/view?usp=sharing

The link is open to everyone and should have the quality required.