### PR TITLE
update synth subnet logo

### DIFF
--- a/data/50/subnet.json
+++ b/data/50/subnet.json
@@ -7,7 +7,7 @@
     "https://github.com/mode-network/synth-subnet"
   ],
   "hw_requirements": "",
-  "image_url": "https://backprop.finance/assets/subnet-logos/50/v2.jpg",
+  "image_url": "https://backprop.finance/assets/subnet-logos/50/v3.jpg",
   "description": "",
   "bittensor_discord_id": "1311109830282313781",
   "team": "Mode Network",

--- a/subnets.json
+++ b/subnets.json
@@ -1564,7 +1564,7 @@
             "https://github.com/mode-network/synth-subnet"
         ],
         "hw_requirements": "",
-        "image_url": "https://backprop.finance/assets/subnet-logos/50/v2.jpg",
+        "image_url": "https://backprop.finance/assets/subnet-logos/50/v3.jpg",
         "description": "",
         "bittensor_discord_id": "1311109830282313781",
         "team": "Mode Network",


### PR DESCRIPTION
https://drive.google.com/file/d/1vEs9l_0Gcq_wByiacaM1UphQfJ5UzKmk/view?usp=drive_link
![synth-logo-400](https://github.com/user-attachments/assets/3031430d-5438-4956-9138-cd60ec0c210d)

please, change our logo. we have had rebranding.